### PR TITLE
Add The Linh Times to Linh's Newswall

### DIFF
--- a/db.js
+++ b/db.js
@@ -36,6 +36,12 @@ module.exports = {
       name: 'Wall Street Journal',
       url: freedom_forum_url('wsj'),
       scale: 1.04,
+    },
+    {
+      id: 'LinhTimes',
+      name: 'The Linh Times',
+      url: () => 'https://linh-news.fly.dev/pdf/latest?token=rbxGtp1zSCdI09rUI6LHq9vri-bIlG9eey9enXuVRoA',
+      scale: 1.0
     }
   ],
 
@@ -114,16 +120,20 @@ module.exports = {
       showFahrenheit: false,
       newspapers: [
         {
-          id: 'NYT',
+          id: 'LinhTimes',
           displayFor: 60
         },
         {
+          id: 'NYT',
+          displayFor: 15
+        },
+        {
           id: 'WSJ',
-          displayFor: 45
+          displayFor: 15
         },
         {
           id: 'LATimes',
-          displayFor: 30
+          displayFor: 15
         },
         {
           id: 'WaPo',

--- a/db.js
+++ b/db.js
@@ -40,7 +40,7 @@ module.exports = {
     {
       id: 'LinhTimes',
       name: 'The Linh Times',
-      url: () => 'https://linh-news.fly.dev/pdf/latest?token=rbxGtp1zSCdI09rUI6LHq9vri-bIlG9eey9enXuVRoA',
+      url: () => `https://linh-news.fly.dev/pdf/latest?token=${process.env.LINH_TIMES_TOKEN}`,
       scale: 1.0
     }
   ],


### PR DESCRIPTION
## Summary
- Adds **The Linh Times** as a newspaper sourced from the tokenized `linh-news.fly.dev/pdf/latest` endpoint (date-independent, always returns the most recent edition).
- Slots it into Linh's Newswall device rotation: 60s primary, with NYT/WSJ/LATimes/WaPo each at 15s.
- `scale: 1.0` (no zoom needed for the Linh Times PDF layout).

Overlaps with #30 — this is an alternative that uses the `latest` endpoint with auth token instead of date-stamped URLs.

## Test plan
- [x] `db.js` loads cleanly; server boots and prints LinhTimes in the newspapers table with the new URL/scale.
- [x] `curl https://linh-news.fly.dev/pdf/latest?token=...` returns a valid `application/pdf`.
- [x] `POST /latest {uuid: "45004e00-1950-3151-4133-362000000000"}` resolves to Linh's Newswall with the new newspaper rotation.
- [ ] End-to-end PDF→PNG render verified in deployed environment (couldn't verify locally; `canvas` native module not built on Windows).