### PR TITLE
Add The Linh Times to Linh's Newswall

### DIFF
--- a/db.js
+++ b/db.js
@@ -40,7 +40,7 @@ module.exports = {
     {
       id: 'LinhTimes',
       name: 'The Linh Times',
-      url: () => `https://linh-news.fly.dev/pdf/latest?token=${process.env.LINH_TIMES_TOKEN}`,
+      url: date => `https://linh-news.fly.dev/pdf/${date.format('YYYY-MM-DD')}?token=${process.env.LINH_TIMES_TOKEN}`,
       scale: 1.0
     }
   ],


### PR DESCRIPTION
## Summary
- Add The Linh Times newspaper source with date-stamped PDF URL
- Read auth token from `LINH_TIMES_TOKEN` env var
- Make Linh Times the primary paper in Linh's rotation (60s), trimming other slots to 15s

## Test plan
- [ ] Verify `LINH_TIMES_TOKEN` is set in deployment env
- [ ] Confirm Linh Times PDF loads on the wall
- [ ] Confirm rotation timings render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)