### PR TITLE
Limit alwaysDownload to today's papers

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,7 +79,8 @@ const download = (newspaper, date) => {
   const pngPath = pdfPath.replace('.pdf', '.png')
   const name = `'${newspaper.name}' for ${date}`
 
-  if (!newspaper.alwaysDownload && fs.existsSync(pdfPath)) {
+  const shouldForceDownload = newspaper.alwaysDownload && date === recentDays(1)[0]
+  if (!shouldForceDownload && fs.existsSync(pdfPath)) {
     return fs.existsSync(pngPath) ? Promise.resolve(log.debug(`Already downloaded ${name}`)) : pdfToImage(pdfPath, pngPath)
   }
 

--- a/db.js
+++ b/db.js
@@ -10,7 +10,7 @@ module.exports = {
   // But, any url as a function of date works e.g. for NYT, this works too (albeit with slight adjustment of the scale param):
   // url: date => `https://static01.nyt.com/images/${date.format('YYYY/MM/DD')}/nytfrontpage/scan.pdf`
   //
-  // alwaysDownload: If set; always download and overwrite the local paper. This should likely be set to false as you'd be flagged by the servers
+  // alwaysDownload: If set, redownload and overwrite today's local paper on every refresh (useful for intraday-updated sources)
   // scale: Gets compiled to transform: scale(x) CSS style to zoom in to remove useless white margins. Use the emulator on homepage to experiment
   newspapers: [
     {


### PR DESCRIPTION
### Motivation
- Avoid repeated downloads for archived days while still allowing selected sources to refresh intraday for the current day.

### Description
- Add `shouldForceDownload = newspaper.alwaysDownload && date === recentDays(1)[0]` and only bypass the cache when `shouldForceDownload` is true, and update the `alwaysDownload` comment to document it applies to today's paper.

### Testing
- Ran `npm test -- --runInBand`, which failed in this environment because `jest` is not installed (`sh: 1: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a45bbfb88320be084135cf42e705)