### PR TITLE
Remove duplicate NYT entry from Linh's Newswall

### DIFF
--- a/db.js
+++ b/db.js
@@ -133,10 +133,6 @@ module.exports = {
           displayFor: 30
         },
         {
-          id: 'NYT',
-          displayFor: 15
-        },
-        {
           id: 'WSJ',
           displayFor: 15
         },


### PR DESCRIPTION
## Summary
- Removes duplicate NYT entry (15m) in Linh's Newswall device rotation; one NYT slot at 30m remains.

## Test plan
- [ ] Verify Linh's Newswall rotation: LinhTimes 45m → NYT 30m → WSJ 15m → LATimes 15m → WaPo 15m